### PR TITLE
Duplicate items fix #11 

### DIFF
--- a/Scripts/Inventory/InventorySlot.cs
+++ b/Scripts/Inventory/InventorySlot.cs
@@ -184,6 +184,30 @@ public class InventorySlot : ItemHolder
 			}
 		}
 
+		// Scan OtherInventorySlot for items of the same type and combine them to the cursor
+		if (Inventory.OtherInventory != null)
+		{
+			foreach (var slot in Inventory.OtherInventory.InventorySlots)
+			{
+				// Skip the slot we double clicked on
+				if (slot == this)
+					continue;
+
+				var invItem = slot.InventoryItem;
+
+				// A item exists in this inv slot
+				if (invItem != null)
+				{
+					// The inv slot item is the same type as the cursor item type
+					if (invItem.Item.Type == itemToMergeTo.Type)
+					{
+						otherItemCounts += invItem.Item.Count;
+
+						slot.RemoveItem();
+					}
+				}
+			}
+		}
 		var counts = itemToMergeTo.Count + otherItemCounts;
 		itemToMergeTo.Count = counts;
 		Main.ItemCursor.SetItem(itemToMergeTo);

--- a/Scripts/Inventory/InventorySlot.cs
+++ b/Scripts/Inventory/InventorySlot.cs
@@ -215,6 +215,9 @@ public class InventorySlot : ItemHolder
 		if (emptySlot == -1)
 			return;
 
+		//Close Item Panels
+		ItemPanelDescription.Clear();
+
 		// Store temporary reference to the item in this inventory slot
 		var itemRef = InventoryItem.Item;
 

--- a/Scripts/Inventory/ItemCursor.cs
+++ b/Scripts/Inventory/ItemCursor.cs
@@ -61,6 +61,7 @@ public class ItemCursor : ItemHolder
 	public override void RemoveItem()
 	{
 		ItemPanelDescription.ToggleVisiblity(true);
+		Item = null;
 
 		// Only move the parent when there is an item in this cursor
 		Parent.SetPhysicsProcess(false);

--- a/Scripts/Inventory/ItemHolder.cs
+++ b/Scripts/Inventory/ItemHolder.cs
@@ -50,9 +50,9 @@ public abstract class ItemHolder
 	/// </summary>
 	public void PlaceOne(ItemHolder from)
 	{
-		from.PickupOne();
-
 		var item = from.Item.Clone();
+		from.PickupOne();
+		
 		item.Count = 1;
 
 		if (Item != null)


### PR DESCRIPTION
#11 
I added logs and identified than on UtilsInventory.HotbarInv() the item count is duplicating because itemHolder.Item.Count & hotbarSlot.InventoryItem.Item.Count both contains the original itemcount when only one should have it.

![image](https://github.com/Valks-Games/Inventory/assets/8868919/029b1001-a053-413b-9e58-4fde36ea0ffa)

Logs:
Hotbar from Cursor
HotbarInv Empty slot, setitem: {
  "Type": {
    "Name": "Pink Coin",
    "Description": "A coin with a pink tint to it"
  },
  "Count": 9
}
Hotbar from Cursor
**HotbarInv itemHolder.Item.Count: 9
HotbarInv hotbarSlot.InventoryItem.Item.Count: 9**
HotbarInv Merging{
  "Type": {
    "Name": "Pink Coin",
    "Description": "A coin with a pink tint to it"
  },
  "Count": 18
}

Based on this I identified than ItemCursor.RemoveItem() is not cleaning the Item value as I expected.

I can not longer duplicate items with this method after this fix.

----------------------

I want to use your project as an template for an Diablo 2 like inventory:

![image](https://github.com/Valks-Games/Inventory/assets/8868919/f54b6e5c-0838-45c6-9ece-ebf27d7ae547)
I will try to add the following features:
-item max stacking count per Item class.
-inventory slots for equipment per Item Type.
-Items taking multiple slots (square/rectangle)

Let me know if you want to colaborate on developing them.
Regards :)
